### PR TITLE
docs: emphasize clarifying questions in style guides

### DIFF
--- a/fast_rules/fastapi_project/core.mdc
+++ b/fast_rules/fastapi_project/core.mdc
@@ -22,6 +22,7 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - Emoji usage is restricted to ✅, ⚠️, and ❌ when reporting test or verification results; NEVER use other emojis unless instructed.
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
+- ALWAYS ask a clarifying question when the user’s request is vague or missing essential context.
 
 ## Implementation Rules
 

--- a/fast_rules/spring_project/core.mdc
+++ b/fast_rules/spring_project/core.mdc
@@ -22,6 +22,7 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - Emoji usage is restricted to ✅, ⚠️, and ❌ when reporting test or verification results; NEVER use other emojis unless instructed.
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
+- ALWAYS ask a clarifying question when the user’s request is vague or missing essential context.
 
 ## Implementation Rules
 

--- a/production_rules/fastapi_project/core.mdc
+++ b/production_rules/fastapi_project/core.mdc
@@ -20,6 +20,7 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - Emoji usage is restricted to ✅, ⚠️, and ❌ when reporting test or verification results; NEVER use other emojis unless instructed.
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
+- ALWAYS ask a clarifying question when the user’s request is vague or missing essential context.
 
 ---
 

--- a/production_rules/spring_project/core.mdc
+++ b/production_rules/spring_project/core.mdc
@@ -20,6 +20,7 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - Emoji usage is restricted to ✅, ⚠️, and ❌ when reporting test or verification results; NEVER use other emojis unless instructed.
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
+- ALWAYS ask a clarifying question when the user’s request is vague or missing essential context.
 
 ---
 


### PR DESCRIPTION
## Summary
- Require asking clarifying questions in tone & style rules for production and fast development guides

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfa15087b483269cf30808cd7de461