### PR TITLE
docs: add reasoning guidance

### DIFF
--- a/fast_rules/fastapi_project/core.mdc
+++ b/fast_rules/fastapi_project/core.mdc
@@ -23,6 +23,10 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+## Reasoning
+
+- For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.
+
 ## Implementation Rules
 
 ### **Rapid Execution with Context**

--- a/fast_rules/spring_project/core.mdc
+++ b/fast_rules/spring_project/core.mdc
@@ -23,6 +23,10 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+## Reasoning
+
+- For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.
+
 ## Implementation Rules
 
 ### **Rapid Execution with Context**

--- a/production_rules/fastapi_project/core.mdc
+++ b/production_rules/fastapi_project/core.mdc
@@ -21,6 +21,10 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+**Reasoning**
+
+- For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.
+
 ---
 
 **Research & Planning**

--- a/production_rules/spring_project/core.mdc
+++ b/production_rules/spring_project/core.mdc
@@ -21,6 +21,10 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+**Reasoning**
+
+- For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.
+
 ---
 
 **Research & Planning**


### PR DESCRIPTION
## Summary
- add "Reasoning" subsection with guidance in core rule docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfa151f9e88326a4cf036a0aeabeb9