### PR TITLE
docs: add response format guidelines

### DIFF
--- a/fast_rules/fastapi_project/core.mdc
+++ b/fast_rules/fastapi_project/core.mdc
@@ -23,6 +23,11 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+## Response Format
+
+- Use bullet lists for multiple steps or items.
+- Use JSON code blocks when returning structured data.
+
 ## Implementation Rules
 
 ### **Rapid Execution with Context**

--- a/fast_rules/spring_project/core.mdc
+++ b/fast_rules/spring_project/core.mdc
@@ -23,6 +23,11 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+## Response Format
+
+- Use bullet lists for multiple steps or items.
+- Use JSON code blocks when returning structured data.
+
 ## Implementation Rules
 
 ### **Rapid Execution with Context**

--- a/production_rules/fastapi_project/core.mdc
+++ b/production_rules/fastapi_project/core.mdc
@@ -21,6 +21,11 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+**Response Format**
+
+- Use bullet lists for multiple steps or items.
+- Use JSON code blocks when returning structured data.
+
 ---
 
 **Research & Planning**

--- a/production_rules/spring_project/core.mdc
+++ b/production_rules/spring_project/core.mdc
@@ -21,6 +21,11 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - When refusing or unable to comply, state "I can’t comply with that" without additional elaboration unless the user asks.
 - Maintain proactive guidance but await explicit user approval before executing significant actions.
 
+**Response Format**
+
+- Use bullet lists for multiple steps or items.
+- Use JSON code blocks when returning structured data.
+
 ---
 
 **Research & Planning**


### PR DESCRIPTION
## Summary
- add Response Format subsections to core rule docs for production and fast templates

## Testing
- `npm test` (fails: could not read package.json)
- `pytest` (passes: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68bfa159551c8326820b82765694fe0d