### PR TITLE
docs: add XML tagging guidelines to core rules

### DIFF
--- a/fast_rules/fastapi_project/core.mdc
+++ b/fast_rules/fastapi_project/core.mdc
@@ -29,6 +29,12 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - Use bullet lists for multiple steps or items.
 - Use JSON code blocks when returning structured data.
 
+### XML Tagging
+
+- ALWAYS wrap internal reasoning in `<analysis>`…`</analysis>`.
+- ALWAYS wrap the user-visible answer in `<final>`…`</final>`.
+- NEVER output text outside these tags.
+
 ## Reasoning
 
 - For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.

--- a/fast_rules/spring_project/core.mdc
+++ b/fast_rules/spring_project/core.mdc
@@ -29,6 +29,12 @@ These rules ALWAYS apply to fast-paced development tasks requiring system awaren
 - Use bullet lists for multiple steps or items.
 - Use JSON code blocks when returning structured data.
 
+### XML Tagging
+
+- ALWAYS wrap internal reasoning in `<analysis>`…`</analysis>`.
+- ALWAYS wrap the user-visible answer in `<final>`…`</final>`.
+- NEVER output text outside these tags.
+
 ## Reasoning
 
 - For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.

--- a/production_rules/fastapi_project/core.mdc
+++ b/production_rules/fastapi_project/core.mdc
@@ -27,6 +27,12 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - Use bullet lists for multiple steps or items.
 - Use JSON code blocks when returning structured data.
 
+**XML Tagging**
+
+- ALWAYS wrap internal reasoning in `<analysis>`…`</analysis>`.
+- ALWAYS wrap the user-visible answer in `<final>`…`</final>`.
+- NEVER output text outside these tags.
+
 **Reasoning**
 
 - For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.

--- a/production_rules/spring_project/core.mdc
+++ b/production_rules/spring_project/core.mdc
@@ -27,6 +27,12 @@ Act as a highly skilled and meticulous senior colleague/architect who operates u
 - Use bullet lists for multiple steps or items.
 - Use JSON code blocks when returning structured data.
 
+**XML Tagging**
+
+- ALWAYS wrap internal reasoning in `<analysis>`…`</analysis>`.
+- ALWAYS wrap the user-visible answer in `<final>`…`</final>`.
+- NEVER output text outside these tags.
+
 **Reasoning**
 
 - For complex tasks, draft internal step-by-step reasoning, then provide a concise final answer.


### PR DESCRIPTION
## Summary
- add XML Tagging sub-section to response format guidelines for production FastAPI and Spring rules
- add XML Tagging sub-section to response format guidelines for fast FastAPI and Spring rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfaa4cea4c8326b316d4940b47b5de